### PR TITLE
Remove content disposition header

### DIFF
--- a/app/api/result/route.tsx
+++ b/app/api/result/route.tsx
@@ -42,14 +42,10 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     headers: download
       ? {
           "Content-Type": "text/plain",
-          "Content-Disposition": `attachment; filename=${techOptions.join(
-            "_",
-          )}.gitignore`,
           "Content-Length": resultText.length.toString(),
         }
       : {
           "Content-Type": "text/plain",
-          "Content-Disposition": `filename=${techOptions.join("_")}.gitignore`,
         },
   });
 }


### PR DESCRIPTION
Seems to be working fine without the header. The raw code mode doesn't try to download any file now.